### PR TITLE
build: update Jetpack Compose dependencies and version catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.0"
+        kotlinCompilerExtensionVersion = "1.5.14"
     }
 
     buildTypes {
@@ -54,21 +54,21 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     
-    implementation ("androidx.activity:activity-compose:1.8.2")
-    implementation (platform("androidx.compose:compose-bom:2022.10.00"))
-    implementation ("androidx.compose.ui:ui:1.5.0")
-    implementation ("androidx.compose.ui:ui-graphics:1.5.0")
-    implementation ("androidx.compose.ui:ui-tooling-preview:1.5.0")
-    implementation ("androidx.compose.material:material:1.5.0")
-    implementation ("androidx.compose.material3:material3:1.1.0")
-    implementation ("androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1")
-    implementation ("androidx.compose.runtime:runtime-livedata:1.5.0")
-    implementation ("androidx.compose.runtime:runtime:1.5.0")
+    implementation(libs.androidx.activity.compose)
+    implementation(platform(libs.androidx.compose.bom))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material:material")
+    implementation("androidx.compose.material3:material3")
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation("androidx.compose.runtime:runtime-livedata")
+    implementation("androidx.compose.runtime:runtime")
 
-    debugImplementation("androidx.compose.ui:ui-tooling:1.5.0")
+    debugImplementation("androidx.compose.ui:ui-tooling")
 
-    implementation ("androidx.constraintlayout:constraintlayout-compose:1.0.1")
-    implementation("androidx.navigation:navigation-compose:2.8.0")
+    implementation(libs.androidx.constraintlayout.compose)
+    implementation(libs.androidx.navigation.compose)
 
     implementation("io.insert-koin:koin-android:3.4.0")
     implementation("io.insert-koin:koin-core:3.4.0")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.5.1"
-kotlin = "1.9.0"
+kotlin = "1.9.24"
 coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -8,7 +8,12 @@ espressoCore = "3.6.1"
 appcompat = "1.7.0"
 material = "1.12.0"
 activity = "1.9.2"
+activityCompose = "1.9.2"
 constraintlayout = "2.1.4"
+constraintlayoutCompose = "1.1.0"
+composeBom = "2024.09.03"
+lifecycleViewModelCompose = "2.8.6"
+navigationCompose = "2.8.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -18,9 +23,13 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-constraintlayout-compose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "constraintlayoutCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-


### PR DESCRIPTION
### Motivation
- Bring Jetpack/Compose dependencies up to newer, consistent versions and centralize them in the version catalog to avoid scattered hardcoded versions.
- Align the Kotlin/Compose compiler extension with the updated Compose artifacts for compatibility.

### Description
- Updated `gradle/libs.versions.toml` to bump Kotlin to `1.9.24`, add Compose BOM `2024.09.03`, and add aliases for `activity-compose`, `constraintlayout-compose`, `lifecycle-viewmodel-compose`, and `navigation-compose` with versions `1.9.2`, `1.1.0`, `2.8.6`, and `2.8.2` respectively.
- Modified `app/build.gradle.kts` to use the version-catalog aliases and the Compose BOM, removing hardcoded Compose artifact versions and using `platform(libs.androidx.compose.bom)` where appropriate.
- Updated `kotlinCompilerExtensionVersion` to `1.5.14` in `app/build.gradle.kts` to match the updated Compose toolchain.

### Testing
- Ran a local assemble attempt with `./gradlew :app:assembleDebug`, which failed due to an environment proxy preventing Gradle distribution download (HTTP 403) so the build could not be completed.
- Repository checks and basic file edits were validated locally (files modified: `app/build.gradle.kts`, `gradle/libs.versions.toml`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b334801388330a31323a5a1dfa150)